### PR TITLE
fix: separate total retry timelimit from individual request timelimit

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,14 +19,16 @@ type Client struct {
 	retryConfig retryConfig
 }
 
-// NewClient creates a new webhook client. The default config uses a timeout for each individual request of 1 minute,
-// and a maximum of 15 retries with exponential backoff starting at 500ms.
+// NewClient creates a new webhook client. The default config uses a timeout for each
+// individual request of 10 seconds, and a maximum of 15 retries with exponential backoff
+// starting at 500ms, and a total timeout for all retries of 5 minutes.
 func NewClient(opts ...ClientOptionFunc) *Client {
 	client := Client{
 		client:  &http.Client{},
-		Timeout: 1 * time.Second,
+		Timeout: 10 * time.Second,
 		retryConfig: retryConfig{
 			maxRetries: 15,
+			maxTime:    5 * time.Minute,
 			backoff:    ExponentialBackoff(500*time.Millisecond, 1*time.Minute),
 			retryable:  IsRetryable,
 		},
@@ -43,7 +45,10 @@ func (c *Client) Send(url string, payload any) error {
 	return c.SendCtx(context.Background(), url, payload)
 }
 
-// Send a webhook payload to the specified url with a given context.
+// SendCtx sends a webhook payload to the specified url with a given context.
+// ctx should not have a timeout set since Send manages this internally both
+// for individual requests and the total time for all retries. Cancellation
+// via ctx still happens.
 func (c *Client) SendCtx(ctx context.Context, url string, payload any) error {
 	return retry(ctx, c.retryConfig, func() error {
 		return c.send(ctx, url, payload)

--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ func (c *Client) send(ctx context.Context, url string, payload any) error {
 		return err
 	}
 	br := bytes.NewReader(b)
-	r, err := http.NewRequest(c.Method, url, br)
+	r, err := http.NewRequestWithContext(ctx, c.Method, url, br)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,6 @@ func (c *Client) send(ctx context.Context, url string, payload any) error {
 		r.Header.Set(key, strings.Join(value, " "))
 	}
 	r.Header.Set("Content-Type", "application/json")
-	r = r.WithContext(ctx)
 
 	res, err := c.client.Do(r)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -93,7 +93,7 @@ func TestClientWithHeaders(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient(
-		ClientOpts.WithTimeout(50*time.Millisecond),
+		ClientOpts.WithRequestTimeout(50*time.Millisecond),
 		ClientOpts.WithBackoffFunc(NoBackoff()),
 		ClientOpts.WithHeaders(http.Header{
 			"x-version":  []string{"1.2.3"},
@@ -114,7 +114,7 @@ func TestClientTimeout(t *testing.T) {
 
 	c := NewClient(
 		ClientOpts.WithRetries(3),
-		ClientOpts.WithTimeout(50*time.Millisecond),
+		ClientOpts.WithRequestTimeout(50*time.Millisecond),
 		ClientOpts.WithBackoffFunc(NoBackoff()),
 	)
 	err := c.Send(server.URL, "this is a test")
@@ -169,7 +169,7 @@ func TestRetryTimelimit(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient(
-		ClientOpts.WithTimeout(10*time.Millisecond), // Individual request timeout
+		ClientOpts.WithRequestTimeout(10*time.Millisecond),
 		ClientOpts.WithBackoffFunc(LinearBackoff(4*time.Millisecond, 100*time.Millisecond)),
 	)
 

--- a/client_test.go
+++ b/client_test.go
@@ -181,3 +181,24 @@ func TestRetryTimelimit(t *testing.T) {
 	}
 	t.Log(err)
 }
+
+func TestRetryTimeout(t *testing.T) {
+	count := 0
+	server := NewBadServer(t, 20, func(cr *capturedRequest) {
+		count += 1
+		t.Logf("request %d", count)
+	})
+	defer server.Close()
+
+	c := NewClient(
+		ClientOpts.WithTimeout(50*time.Millisecond),
+		ClientOpts.WithBackoffFunc(LinearBackoff(10*time.Millisecond, 1*time.Minute)),
+	)
+	err := c.Send(server.URL, "this is a test")
+	if count > 5 {
+		t.Errorf("didn't expect more than %d attempts, got %d attempts", 5, count)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected to get context deadline exceeded, got %v", err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -106,7 +106,9 @@ func TestClientWithHeaders(t *testing.T) {
 }
 
 func TestClientTimeout(t *testing.T) {
+	count := 0
 	server := NewSlowServer(t, 200*time.Millisecond, http.StatusOK, func(r *capturedRequest) {
+		count += 1
 	})
 	defer server.Close()
 
@@ -116,10 +118,11 @@ func TestClientTimeout(t *testing.T) {
 		ClientOpts.WithBackoffFunc(NoBackoff()),
 	)
 	err := c.Send(server.URL, "this is a test")
-	if err == nil {
-		t.Error("expected timeout error, got nil")
-	} else {
-		t.Log(err)
+	if count != 3 {
+		t.Errorf("expected %d attempts, got %d attempts", 3, count)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error(err)
 	}
 }
 
@@ -157,21 +160,6 @@ func TestClientCancel(t *testing.T) {
 	}
 }
 
-func TestClientCtxTimeout(t *testing.T) {
-	server := NewBadServer(t, 5, func(cr *capturedRequest) {})
-	defer server.Close()
-
-	c := NewClient(
-		ClientOpts.WithBackoffFunc(ConstantBackoff(1 * time.Minute)),
-	)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	err := c.SendCtx(ctx, server.URL, "this is a test")
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Error(err)
-	}
-}
-
 func TestRetryTimelimit(t *testing.T) {
 	count := 0
 	server := NewSlowServer(t, 20*time.Millisecond, http.StatusOK, func(cr *capturedRequest) {
@@ -185,9 +173,7 @@ func TestRetryTimelimit(t *testing.T) {
 		ClientOpts.WithBackoffFunc(LinearBackoff(4*time.Millisecond, 100*time.Millisecond)),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Millisecond) // Should also be individual request timeout
-	defer cancel()
-	err := c.SendCtx(ctx, server.URL, "this is a test")
+	err := c.SendCtx(context.Background(), server.URL, "this is a test")
 
 	// All retries should have gone through
 	if count != 15 {

--- a/client_test.go
+++ b/client_test.go
@@ -171,3 +171,27 @@ func TestClientCtxTimeout(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestRetryTimelimit(t *testing.T) {
+	count := 0
+	server := NewSlowServer(t, 20*time.Millisecond, http.StatusOK, func(cr *capturedRequest) {
+		count += 1
+		t.Logf("request %d", count)
+	})
+	defer server.Close()
+
+	c := NewClient(
+		ClientOpts.WithTimeout(10*time.Millisecond), // Individual request timeout
+		ClientOpts.WithBackoffFunc(LinearBackoff(4*time.Millisecond, 100*time.Millisecond)),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Millisecond) // Should also be individual request timeout
+	defer cancel()
+	err := c.SendCtx(ctx, server.URL, "this is a test")
+
+	// All retries should have gone through
+	if count != 15 {
+		t.Errorf("expected %d requests, got %d requests", 15, count)
+	}
+	t.Log(err)
+}

--- a/options.go
+++ b/options.go
@@ -12,10 +12,17 @@ type (
 
 var ClientOpts ClientOptions = struct{}{}
 
-// WithTimout sets the timeout for individual webhook requests.
-func (o ClientOptions) WithTimeout(timeout time.Duration) ClientOptionFunc {
+// WithRequestTimeout sets the timeout for individual webhook requests.
+func (o ClientOptions) WithRequestTimeout(timeout time.Duration) ClientOptionFunc {
 	return func(c *Client) {
 		c.Timeout = timeout
+	}
+}
+
+// WithTimeout sets the total timeout for all attempts.
+func (o ClientOptions) WithTimeout(timeout time.Duration) ClientOptionFunc {
+	return func(c *Client) {
+		c.retryConfig.maxTime = timeout
 	}
 }
 

--- a/retry.go
+++ b/retry.go
@@ -15,6 +15,8 @@ type (
 type retryConfig struct {
 	// maxRetries is the maximum number of times to retry execution
 	maxRetries int
+	// maxTime is the maximum time allowed for all retries
+	maxTime time.Duration
 	// backoff determines the amount of time to wait until the next attempt as a function of the number of attempts.
 	backoff BackoffFunc
 	// retryable determines what types of errors should be retried as a function of the error.
@@ -24,6 +26,8 @@ type retryConfig struct {
 // retry retries the execution of a function if the function returns an error.
 // The behaviour of the retrying is controlled by retryConfig.
 func retry(ctx context.Context, cfg retryConfig, fn func() error) error {
+	ctx, cancel := context.WithTimeout(ctx, cfg.maxTime)
+	defer cancel()
 	var err error
 	for attempt := range cfg.maxRetries {
 		slog.Info("retrying function call", "attempt", attempt)

--- a/retry_test.go
+++ b/retry_test.go
@@ -45,6 +45,9 @@ func TestExponentialBackoff(t *testing.T) {
 		{"0 tries", 0, 0},
 		{"1 tries", 1, 500 * time.Millisecond},
 		{"2 tries", 2, 1 * time.Second},
+		{"3 tries", 3, 2 * time.Second},
+		{"4 tries", 4, 4 * time.Second},
+		{"5 tries", 5, 8 * time.Second},
 		{"100 tries", 100, 1 * time.Minute},
 	}
 
@@ -66,6 +69,8 @@ func TestLinearBackoff(t *testing.T) {
 		{"1 tries", 1, 500 * time.Millisecond},
 		{"2 tries", 2, 1000 * time.Millisecond},
 		{"3 tries", 3, 1500 * time.Millisecond},
+		{"4 tries", 4, 2000 * time.Millisecond},
+		{"5 tries", 5, 2500 * time.Millisecond},
 	}
 
 	for _, c := range testcases {

--- a/retry_test.go
+++ b/retry_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestRetry(t *testing.T) {
 	cfg := retryConfig{
+		maxTime:    10 * time.Second,
 		maxRetries: 5,
 		backoff:    func(n int) time.Duration { return 0 * time.Second },
 		retryable:  func(error) bool { return true },


### PR DESCRIPTION
Closes #2 