### PR TITLE
feat: return a result from `Client.Send`

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,7 +46,9 @@ func NewClient(opts ...ClientOptionFunc) *Client {
 	return &client
 }
 
-// Send a webhook payload to the specified url.
+// Send a webhook payload to the specified url. `Result.Response` can be nil
+// if a non-nil error is returned, but will always be defined if a nil error
+// is returned.
 func (c *Client) Send(url string, payload any) (Result, error) {
 	return c.SendContext(context.Background(), url, payload)
 }
@@ -54,7 +56,8 @@ func (c *Client) Send(url string, payload any) (Result, error) {
 // SendContext sends a webhook payload to the specified url with a given context.
 // ctx should not have a timeout set since Send manages this internally both
 // for individual requests and the total time for all retries. Cancellation
-// via ctx still happens.
+// via ctx still happens. `Result.Response` can be nil if a non-nil error is
+// returned, but will always be defined if a nil error is returned.
 func (c *Client) SendContext(ctx context.Context, url string, payload any) (Result, error) {
 	var result Result
 	attempts, retryErr := retry(ctx, c.retryConfig, func() error {

--- a/client.go
+++ b/client.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+// Result is a result from Send on a webhook client.
+type Result struct {
+	Response *http.Response
+	Attempts int
+}
+
 // Client is a webhook client.
 type Client struct {
 	client *http.Client
@@ -41,7 +47,7 @@ func NewClient(opts ...ClientOptionFunc) *Client {
 }
 
 // Send a webhook payload to the specified url.
-func (c *Client) Send(url string, payload any) error {
+func (c *Client) Send(url string, payload any) (Result, error) {
 	return c.SendContext(context.Background(), url, payload)
 }
 
@@ -49,38 +55,46 @@ func (c *Client) Send(url string, payload any) error {
 // ctx should not have a timeout set since Send manages this internally both
 // for individual requests and the total time for all retries. Cancellation
 // via ctx still happens.
-func (c *Client) SendContext(ctx context.Context, url string, payload any) error {
-	return retry(ctx, c.retryConfig, func() error {
-		return c.send(ctx, url, payload)
+func (c *Client) SendContext(ctx context.Context, url string, payload any) (Result, error) {
+	var result Result
+	attempts, retryErr := retry(ctx, c.retryConfig, func() error {
+		resp, err := c.send(ctx, url, payload)
+		if resp != nil {
+			result.Response = resp
+		}
+		return err
 	})
+	result.Attempts = attempts
+	return result, retryErr
 }
 
-func (c *Client) send(ctx context.Context, url string, payload any) error {
+func (c *Client) send(ctx context.Context, url string, payload any) (*http.Response, error) {
+	var resp *http.Response
 	b, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return resp, err
 	}
 	br := bytes.NewReader(b)
 	r, err := http.NewRequestWithContext(ctx, c.Method, url, br)
 	if err != nil {
-		return err
+		return resp, err
 	}
 	for key, value := range c.Headers {
 		r.Header.Set(key, strings.Join(value, " "))
 	}
 	r.Header.Set("Content-Type", "application/json")
 
-	res, err := c.client.Do(r)
+	resp, err = c.client.Do(r)
 	if err != nil {
-		return err
+		return resp, err
 	}
 
-	if res.StatusCode >= 200 && res.StatusCode < 300 {
-		return nil
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp, nil
 	}
 
-	return WebhookError{
-		StatusCode: res.StatusCode,
-		Status:     res.Status,
+	return resp, WebhookError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -47,6 +47,8 @@ func NewBadServer(t *testing.T, failures int, handler func(*capturedRequest)) *h
 	t.Helper()
 	failureCount := 0
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		handler(&capturedRequest{body: body, header: r.Header})
 		if failureCount >= failures {
 			w.WriteHeader(http.StatusOK)
 			return
@@ -70,9 +72,14 @@ func TestClient(t *testing.T) {
 	defer server.Close()
 
 	c := NewClient()
-	if err := c.Send(server.URL, payload); err != nil {
+	res, err := c.Send(server.URL, payload)
+	if err != nil {
 		t.Error(err)
 	}
+	if res.Response.StatusCode != http.StatusOK {
+		t.Errorf("expected HTTP 200, got %s", res.Response.Status)
+	}
+	t.Log(res)
 }
 
 func TestClientWithHeaders(t *testing.T) {
@@ -100,9 +107,11 @@ func TestClientWithHeaders(t *testing.T) {
 			"user-agent": []string{"webhook-test/1.0"},
 		}),
 	)
-	if err := c.Send(server.URL, payload); err != nil {
+	res, err := c.Send(server.URL, payload)
+	if err != nil {
 		t.Error(err)
 	}
+	t.Log(res)
 }
 
 func TestClientTimeout(t *testing.T) {
@@ -117,9 +126,15 @@ func TestClientTimeout(t *testing.T) {
 		ClientOpts.WithRequestTimeout(50*time.Millisecond),
 		ClientOpts.WithBackoffFunc(NoBackoff()),
 	)
-	err := c.Send(server.URL, "this is a test")
+	res, err := c.Send(server.URL, "this is a test")
+	if count != res.Attempts {
+		t.Errorf("result should have %d attempts, got %d", count, res.Attempts)
+	}
 	if count != 3 {
 		t.Errorf("expected %d attempts, got %d attempts", 3, count)
+	}
+	if res.Response != nil {
+		t.Error("response is non-nil")
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Error(err)
@@ -133,13 +148,22 @@ func TestRateLimit(t *testing.T) {
 }
 
 func TestClientRetryOn500(t *testing.T) {
-	server := NewBadServer(t, 3, func(cr *capturedRequest) {})
+	var count int
+	server := NewBadServer(t, 3, func(cr *capturedRequest) {
+		count += 1
+	})
 	defer server.Close()
 
 	c := NewClient(
 		ClientOpts.WithBackoffFunc(NoBackoff()),
 	)
-	err := c.Send(server.URL, "this is a test")
+	res, err := c.Send(server.URL, "this is a test")
+	if res.Attempts != count {
+		t.Errorf("expected %d attempts in result, got %d", count, res.Attempts)
+	}
+	if res.Response.StatusCode != http.StatusOK {
+		t.Errorf("expected HTTP 200, got %s", res.Response.Status)
+	}
 	if err != nil {
 		t.Error(err)
 	}
@@ -154,7 +178,13 @@ func TestClientCancel(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := c.SendContext(ctx, server.URL, "this is a test")
+	res, err := c.SendContext(ctx, server.URL, "this is a test")
+	if res.Attempts != 1 {
+		t.Errorf("expected %d attempts in result, got %d", 1, res.Attempts)
+	}
+	if res.Response != nil {
+		t.Error("response is non-nil")
+	}
 	if !errors.Is(err, context.Canceled) {
 		t.Error(err)
 	}
@@ -173,13 +203,22 @@ func TestRetryTimelimit(t *testing.T) {
 		ClientOpts.WithBackoffFunc(LinearBackoff(4*time.Millisecond, 100*time.Millisecond)),
 	)
 
-	err := c.SendContext(context.Background(), server.URL, "this is a test")
+	res, err := c.SendContext(context.Background(), server.URL, "this is a test")
+	if count != res.Attempts {
+		t.Errorf("expected %d attempts in result, got %d", count, res.Attempts)
+	}
 
 	// All retries should have gone through
 	if count != 15 {
 		t.Errorf("expected %d requests, got %d requests", 15, count)
 	}
-	t.Log(err)
+	// None of the attempts should have yielded a response
+	if res.Response != nil {
+		t.Error("response is non-nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected deadline exceeded, got %v", err)
+	}
 }
 
 func TestRetryTimeout(t *testing.T) {
@@ -194,11 +233,17 @@ func TestRetryTimeout(t *testing.T) {
 		ClientOpts.WithTimeout(50*time.Millisecond),
 		ClientOpts.WithBackoffFunc(LinearBackoff(10*time.Millisecond, 1*time.Minute)),
 	)
-	err := c.Send(server.URL, "this is a test")
+	res, err := c.Send(server.URL, "this is a test")
+	if count != res.Attempts {
+		t.Errorf("expected %d attempts in result, got %d", count, res.Attempts)
+	}
 	if count > 5 {
 		t.Errorf("didn't expect more than %d attempts, got %d attempts", 5, count)
 	}
+	if res.Response.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected HTTP 500, got %s", res.Response.Status)
+	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("expected to get context deadline exceeded, got %v", err)
+		t.Errorf("expected deadline exceeded, got %v", err)
 	}
 }

--- a/error.go
+++ b/error.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 )
 
@@ -26,7 +25,6 @@ func IsRetryable(err error) bool {
 		return webhookErr.StatusCode == http.StatusTooManyRequests || webhookErr.StatusCode >= http.StatusInternalServerError
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		slog.Info("checking if error is retryable", "error", err)
 		return true
 	}
 	return false

--- a/retry.go
+++ b/retry.go
@@ -24,26 +24,26 @@ type retryConfig struct {
 
 // retry retries the execution of a function if the function returns an error.
 // The behaviour of the retrying is controlled by retryConfig.
-func retry(ctx context.Context, cfg retryConfig, fn func() error) error {
+func retry(ctx context.Context, cfg retryConfig, fn func() error) (int, error) {
 	ctx, cancel := context.WithTimeout(ctx, cfg.maxTime)
 	defer cancel()
 	var err error
 	for attempt := range cfg.maxRetries {
 		err = fn()
 		if err == nil {
-			return nil
+			return attempt + 1, nil
 		}
 		if !cfg.retryable(err) {
-			return err
+			return attempt + 1, err
 		}
 		wait := cfg.backoff(attempt + 1)
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return attempt + 1, ctx.Err()
 		case <-time.After(wait):
 		}
 	}
-	return fmt.Errorf("failed after %d attempts, last error: %w", cfg.maxRetries, err)
+	return cfg.maxRetries, fmt.Errorf("failed after %d attempts, last error: %w", cfg.maxRetries, err)
 }
 
 // NoBackoff returns a BackoffFunc that always returns 0.

--- a/retry.go
+++ b/retry.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 )
 
@@ -30,7 +29,6 @@ func retry(ctx context.Context, cfg retryConfig, fn func() error) error {
 	defer cancel()
 	var err error
 	for attempt := range cfg.maxRetries {
-		slog.Info("retrying function call", "attempt", attempt)
 		err = fn()
 		if err == nil {
 			return nil

--- a/retry_test.go
+++ b/retry_test.go
@@ -19,7 +19,7 @@ func TestRetry(t *testing.T) {
 	attempt := 0
 	start := time.Now()
 
-	err := retry(context.Background(), cfg, func() error {
+	n, err := retry(context.Background(), cfg, func() error {
 		attempt += 1
 		t.Logf("attempt %d after %s", attempt, time.Since(start))
 		if attempt == attempts {
@@ -27,6 +27,9 @@ func TestRetry(t *testing.T) {
 		}
 		return fmt.Errorf("failed")
 	})
+	if n != attempts {
+		t.Errorf("expected %d attempts from retry, got %d", attempts, n)
+	}
 	if attempt != attempts {
 		t.Errorf("expected %d attempts, only saw %d", attempts, attempt)
 	}


### PR DESCRIPTION
This modifies the send methods on the client to return a result, and not only an error. This result contains the http response for the request in question, in addition to the number of attempts made to send the request.

Closes #4 